### PR TITLE
Fixing a call to deleteSession

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -62,9 +62,9 @@ class YouiDriver extends BaseDriver {
     logger.debug("Deleting Youi session");
 
     await this.proxydriver.deleteSession();
+    await super.deleteSession();
 
     await this.stop();
-    await super.deleteSession();
   }
 
   driverShouldDoProxyCmd (command) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "youi.tv"
   },
@@ -57,7 +57,7 @@
     "sinon": "^1.17.1"
   },
   "readme": "ERROR: No README data found!",
-  "_id": "appium-youi-driver@1.0.5",
+  "_id": "appium-youi-driver@1.0.9",
   "_shasum": "e88ece6a8538e448f62f20b981447d2ce006a761",
   "_from": "node_modules/appium-youi-driver",
   "_resolved": "file:node_modules/appium-youi-driver",


### PR DESCRIPTION
It was crashing the server when the ruby scripts finished.

Moved the call to super.deleteSession to before the stop command.